### PR TITLE
Bug fixes & Improvements

### DIFF
--- a/lib/LED_clock/Config/Setup/12h-extended/Configuration.h
+++ b/lib/LED_clock/Config/Setup/12h-extended/Configuration.h
@@ -38,6 +38,8 @@
 		 */
 		#define BLYNK_TEMPLATE_ID "YOUR_TEMPLATE_ID_GOES_HERE"
 
+		#define BLYNK_TEMPLATE_NAME "YOUR_TEMPLATE_NAME_GOES_HERE"
+
 		/**
 		 * \brief Name of this device in the Blynk app
 		 */
@@ -194,7 +196,7 @@
 
 #if USE_NIGHT_MODE == true
 
-	/**
+/**
 	 * \brief Start hour for the night mode
 	 */
 	#define DEFAULT_NIGHT_MODE_START_HOUR 22
@@ -385,17 +387,19 @@ enum DisplayIDs {
 	/**
 	 * \brief AnalogRead value if the light sensor reads complete darkness
 	 */
-	#define LIGHT_SENSOR_MIN			0
+	#define LIGHT_SENSOR_MIN			4095
 
 	/**
 	 * \brief AnalogRead value if the light sensor reads the brightest
 	 */
-	#define LIGHT_SENSOR_MAX			4095
+	#define LIGHT_SENSOR_MAX			0				
 
 	/**
-	 * \brief Value between 0 and 255 that determines how much the light sensor values can influence the led brightness
+	 * \brief The dimming percentage (between 0 and 100) applied to DEFAULT_CLOCK_BRIGHTNESS when the light sensor detects low light conditions
+	 *        Example: DEFAULT_CLOCK_BRIGHTNESS = 128; LIGHT_SENSOR_PERCENTAGE = 85; if the light sensor reads complete darkness (4095),
+	 *        LED brightness will reduced by 85% to 19 brightness
 	 */
-	#define LIGHT_SENSOR_SENSITIVITY	100
+	#define LIGHT_SENSOR_PERCENTAGE		85
 
 #endif
 

--- a/lib/LED_clock/Config/Setup/12h-extended/Configuration.h
+++ b/lib/LED_clock/Config/Setup/12h-extended/Configuration.h
@@ -196,7 +196,7 @@
 
 #if USE_NIGHT_MODE == true
 
-/**
+         /**
 	 * \brief Start hour for the night mode
 	 */
 	#define DEFAULT_NIGHT_MODE_START_HOUR 22

--- a/lib/LED_clock/Config/Setup/12h-extended/Configuration.h
+++ b/lib/LED_clock/Config/Setup/12h-extended/Configuration.h
@@ -194,7 +194,7 @@
 
 #if USE_NIGHT_MODE == true
 
-	/**
+	 /**
 	 * \brief Start hour for the night mode
 	 */
 	#define DEFAULT_NIGHT_MODE_START_HOUR 22

--- a/lib/LED_clock/Config/Setup/12h-extended/Configuration.h
+++ b/lib/LED_clock/Config/Setup/12h-extended/Configuration.h
@@ -194,7 +194,7 @@
 
 #if USE_NIGHT_MODE == true
 
-	 /**
+	/**
 	 * \brief Start hour for the night mode
 	 */
 	#define DEFAULT_NIGHT_MODE_START_HOUR 22

--- a/lib/LED_clock/Config/Setup/24h-clock/Configuration.h
+++ b/lib/LED_clock/Config/Setup/24h-clock/Configuration.h
@@ -38,6 +38,8 @@
 		 */
 		#define BLYNK_TEMPLATE_ID "YOUR_TEMPLATE_ID_GOES_HERE"
 
+		#define BLYNK_TEMPLATE_NAME "YOUR_TEMPLATE_NAME_GOES_HERE"
+
 		/**
 		 * \brief Name of this device in the Blynk app
 		 */
@@ -383,17 +385,19 @@ enum DisplayIDs {
 	/**
 	 * \brief AnalogRead value if the light sensor reads complete darkness
 	 */
-	#define LIGHT_SENSOR_MIN			0
+	#define LIGHT_SENSOR_MIN			4095
 
 	/**
 	 * \brief AnalogRead value if the light sensor reads the brightest
 	 */
-	#define LIGHT_SENSOR_MAX			4095
+	#define LIGHT_SENSOR_MAX			0				
 
 	/**
-	 * \brief Value between 0 and 255 that determines how much the light sensor values can influence the led brightness
+	 * \brief The dimming percentage (between 0 and 100) applied to DEFAULT_CLOCK_BRIGHTNESS when the light sensor detects low light conditions
+	 *        Example: DEFAULT_CLOCK_BRIGHTNESS = 128; LIGHT_SENSOR_PERCENTAGE = 85; if the light sensor reads complete darkness (4095),
+	 *        LED brightness will reduced by 85% to 19 brightness
 	 */
-	#define LIGHT_SENSOR_SENSITIVITY	100
+	#define LIGHT_SENSOR_PERCENTAGE		85
 
 #endif
 

--- a/lib/LED_clock/Config/Setup/diy-machines/Configuration.h
+++ b/lib/LED_clock/Config/Setup/diy-machines/Configuration.h
@@ -38,6 +38,8 @@
 		 */
 		#define BLYNK_TEMPLATE_ID "YOUR_TEMPLATE_ID_GOES_HERE"
 
+		#define BLYNK_TEMPLATE_NAME "YOUR_TEMPLATE_NAME_GOES_HERE"
+
 		/**
 		 * \brief Name of this device in the Blynk app
 		 */
@@ -381,17 +383,19 @@ enum DisplayIDs {
 	/**
 	 * \brief AnalogRead value if the light sensor reads complete darkness
 	 */
-	#define LIGHT_SENSOR_MIN			0
+	#define LIGHT_SENSOR_MIN			4095
 
 	/**
 	 * \brief AnalogRead value if the light sensor reads the brightest
 	 */
-	#define LIGHT_SENSOR_MAX			4095
+	#define LIGHT_SENSOR_MAX			0				
 
 	/**
-	 * \brief Value between 0 and 255 that determines how much the light sensor values can influence the led brightness
+	 * \brief The dimming percentage (between 0 and 100) applied to DEFAULT_CLOCK_BRIGHTNESS when the light sensor detects low light conditions
+	 *        Example: DEFAULT_CLOCK_BRIGHTNESS = 128; LIGHT_SENSOR_PERCENTAGE = 85; if the light sensor reads complete darkness (4095),
+	 *        LED brightness will reduced by 85% to 19 brightness
 	 */
-	#define LIGHT_SENSOR_SENSITIVITY	100
+	#define LIGHT_SENSOR_PERCENTAGE		85
 
 #endif
 

--- a/lib/LED_clock/Modules/ClockState/src/ClockState.cpp
+++ b/lib/LED_clock/Modules/ClockState/src/ClockState.cpp
@@ -65,7 +65,7 @@ void ClockState::handleStates()
 					if(isinNightMode == false)
 					{
 						isinNightMode = true;
-						ShelfDisplays->setGlobalBrightness(nightModeBrightness);
+						ShelfDisplays->setGlobalBrightness(nightModeBrightness, false);
 					}
 				}
 				else
@@ -73,7 +73,7 @@ void ClockState::handleStates()
 					if(isinNightMode == true)
 					{
 						isinNightMode = false;
-						ShelfDisplays->setGlobalBrightness(clockBrightness);
+						ShelfDisplays->setGlobalBrightness(clockBrightness, false);
 					}
 				}
 			#endif

--- a/lib/LED_clock/Modules/DisplayManager/src/DisplayManager.cpp
+++ b/lib/LED_clock/Modules/DisplayManager/src/DisplayManager.cpp
@@ -102,7 +102,7 @@ void DisplayManager::takeBrightnessMeasurement()
 			{
 				BrightnessListSum += lightSensorMeasurements.get(i);
 			}
-			lightSensorBrightnessNew = map(BrightnessListSum / lightSensorMeasurements.size(), 0, 4095, 0, 255);
+			lightSensorBrightnessNew = map(BrightnessListSum / lightSensorMeasurements.size(), 4095, 0, 0, 100);
 		}
 		else
 		{
@@ -120,14 +120,13 @@ void DisplayManager::takeBrightnessMeasurement()
 			{
 				BrightnessListSum += sortedMeasurements.get(i + medianOffset);
 			}
-			lightSensorBrightnessNew = map(BrightnessListSum / LIGHT_SENSOR_MEDIAN_WIDTH, LIGHT_SENSOR_MIN, LIGHT_SENSOR_MAX, LIGHT_SENSOR_SENSITIVITY, 0);
+			lightSensorBrightnessNew = map(BrightnessListSum / LIGHT_SENSOR_MEDIAN_WIDTH, LIGHT_SENSOR_MAX, LIGHT_SENSOR_MIN, 0, LIGHT_SENSOR_PERCENTAGE);
 		}
 		if(lightSensorBrightnessNew != lightSensorBrightness)
 		{
 			lightSensorBrightness = lightSensorBrightnessNew;
 			setGlobalBrightness(currentLEDBrightness);
 		}
-		// Serial.printf("Sensor brightness: %d\n\r", lightSensorBrightness);
 	}
 }
 #endif
@@ -347,10 +346,13 @@ void DisplayManager::setGlobalBrightness(uint8_t brightness, bool enableSmoothTr
 	currentLEDBrightness = brightness;
 
 	#if ENABLE_LIGHT_SENSOR == true
-		LEDBrightnessSetPoint = constrain(brightness - lightSensorBrightness, 0, 255);
+	    double double_lightSensorBrightness = static_cast<double>(lightSensorBrightness);
+		double double_brightness = static_cast<double>(brightness);
+		LEDBrightnessSetPoint = constrain(double_brightness * (1 - (double_lightSensorBrightness / 100)), 0, 255);
 	#else
 		LEDBrightnessSetPoint = brightness;
 	#endif
+
 	if(enableSmoothTransition)
 	{
 		LEDBrightnessSmoothingStartPoint = LEDBrightnessCurrent;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,12 +87,7 @@ void setup()
 {
 	Serial.begin(115200);
 
-	ShelfDisplays->InitSegments(0, NUM_LEDS_PER_SEGMENT, WIFI_CONNECTING_COLOR, 50);
-
-	ShelfDisplays->setHourSegmentColors(HOUR_COLOR);
-	ShelfDisplays->setMinuteSegmentColors(MINUTE_COLOR);
-	ShelfDisplays->setInternalLEDColor(INTERNAL_COLOR);
-	ShelfDisplays->setDotLEDColor(SEPARATION_DOT_COLOR);
+	ShelfDisplays->InitSegments(0, NUM_LEDS_PER_SEGMENT, WIFI_CONNECTING_COLOR, DEFAULT_CLOCK_BRIGHTNESS);
 
 	#if RUN_WITHOUT_WIFI == false
 		wifiSetup();
@@ -116,6 +111,11 @@ void setup()
 	timeM->setTimerTickCallback(TimerTick);
 	timeM->setTimerDoneCallback(TimerDone);
 	timeM->setAlarmCallback(AlarmTriggered);
+
+	ShelfDisplays->setHourSegmentColors(HOUR_COLOR);
+	ShelfDisplays->setMinuteSegmentColors(MINUTE_COLOR);
+	ShelfDisplays->setInternalLEDColor(INTERNAL_COLOR);
+	ShelfDisplays->setDotLEDColor(SEPARATION_DOT_COLOR);
 
 	Serial.println("Displaying startup animation...");
 	startupAnimation();
@@ -282,7 +282,7 @@ void TimerDone()
 			#endif
 			ShelfDisplays->setAllSegmentColors(OTA_UPDATE_COLOR);
 			ShelfDisplays->turnAllLEDsOff(); //instead of the loading animation show a progress bar
-			ShelfDisplays->setGlobalBrightness(50);
+			ShelfDisplays->setGlobalBrightness(DEFAULT_CLOCK_BRIGHTNESS, false);
 		})
 		.onEnd([]()
 		{


### PR DESCRIPTION
- Added missing BLYNK_TEMPLATE_NAME to address build failures with newer versions of Blynk.
- Fixed issue where clock color would default to WIFI_CONNECTION_SUCCESSFUL_COLOR (green) only. It now uses HOUR_COLOR and MINUTE_COLOR as intended.
- Improved light sensor configuration by changing LIGHT_SENSOR_SENSITIVITY control (0-255) to be percentage-based (0-100); this makes it much easier to understand and control. It will dim the LEDs by up to X-percentage when the light sensor detects low light. For example: With LIGHT_SENSOR_PERCENTAGE at 85 and DEFAULT_CLOCK_BRIGHTNESS at 128, if the light sensor detects complete darkness (4095), brightness will be reduced to 19 (15% of 128). This works so much better than before, and it's predictable.
- Along with the above change I updated logic in DisplayManager so LIGHT_SENSOR_MIN and LIGHT_SENSOR_MAX would function correctly. I noticed that several uses (including myself) had to reverse these values because it was dimming the wrong way. The correct setting for these should be LIGHT_SENSOR_MIN = 4095, LIGHT_SENSOR_MAX = 0, at least based on the sensor I was using.  Yes, it's the opposite of what you would think. 4095 = complete darkness.
- Updated hardcoded brightness in two places to DEFAULT_CLOCK_BRIGHTNESS so everything is more consistent and predictable.